### PR TITLE
fix(time): avg. seconds in year

### DIFF
--- a/src/Time.ts
+++ b/src/Time.ts
@@ -93,10 +93,10 @@ export class Time {
   }
 
   /**
-   * @notice ~365.24 days
-   * @return A year in seconds
+   * @notice 365.2425 days
+   * @return An average year in seconds
    */
   static get YearInSeconds(): number {
-    return 31556925
+    return 31556952
   }
 }


### PR DESCRIPTION
Changes avg. seconds in year from julian count to gregorian cal.

Julian | 365.25 | -0.0078 | error rate: 2.14 xx10-5
vs.
Gregorian | 365.2425 | -0.0003 | error rate: 8.2 xx10-7




